### PR TITLE
Allow user to specify origin cell

### DIFF
--- a/src/floodit.cpp
+++ b/src/floodit.cpp
@@ -16,7 +16,8 @@
 #include <stdexcept>
 #include "unionfind.hpp"
 
-Graph::Graph(unsigned numNodes) : nodes(numNodes), colorCounts(1, numNodes) {}
+Graph::Graph(unsigned numNodes)
+	: nodes(numNodes), rootIndex(0), colorCounts(1, numNodes) {}
 
 void Graph::setColor(unsigned index, color_t color)
 {
@@ -51,6 +52,9 @@ void Graph::reduce()
 		if (partitions.find(i) != i)
 			--colorCounts[nodes[i].color];
 	}
+
+	// Update root index.
+	rootIndex = reduced[partitions.find(rootIndex)];
 
 	// Now we merge the neighbor lists.
 	for (unsigned i = 0; i < nodes.size(); ++i) {
@@ -95,7 +99,7 @@ void Graph::reduce()
 
 State::State(const Graph &graph)
 	: graph(&graph), filled(graph.getNumNodes(), false),
-	  moves(1, graph.getNode(0).color)
+	  moves(1, graph.getNode(graph.getRootIndex()).color)
 {
 	// Check that the graph is reduced. We are going to assume that later.
 	for (unsigned index = 0; index < graph.getNumNodes(); ++index) {
@@ -104,7 +108,7 @@ State::State(const Graph &graph)
 			assert(node.color != graph.getNode(neighbor).color);
 	}
 
-	filled[0] = true;
+	filled[graph.getRootIndex()] = true;
 	valuation = computeValuation();
 }
 

--- a/src/floodit.hpp
+++ b/src/floodit.hpp
@@ -25,6 +25,11 @@ public:
 	 */
 	explicit Graph(unsigned numNodes);
 
+	/// Get index of root node.
+	unsigned getRootIndex() const { return rootIndex; }
+	/// Set @p index of root node.
+	void setRootIndex(unsigned index) { rootIndex = index; }
+
 	/**
 	 * Set color of node @p index to @p color.
 	 */
@@ -41,8 +46,7 @@ public:
 	 * We can safely merge adjacent nodes of the same color, because they will
 	 * always be filled together.
 	 *
-	 * @note This will of course renumber the nodes, but node 0 will be part of
-	 * the new node 0.
+	 * @note The old root node will be part of the new root node.
 	 */
 	void reduce();
 
@@ -67,6 +71,8 @@ public:
 
 private:
 	std::vector<Node> nodes;
+	unsigned rootIndex;
+
 	std::vector<unsigned> colorCounts;
 };
 

--- a/src/generator.cpp
+++ b/src/generator.cpp
@@ -4,16 +4,21 @@
 
 int main(int argc, char **argv)
 {
-	if (argc != 4) {
-		std::cout << "Usage: " << argv[0] << " rows columns number-of-colors\n";
+	if (argc != 4 && argc != 6) {
+		std::cout << "Usage: " << argv[0]
+		          << " rows columns [row column] number-of-colors\n";
 		return 1;
 	}
 
 	// Read parameters
-	int rows, columns, numColors;
+	int rows, columns, originRow = 0, originColumn = 0, numColors;
 	std::istringstream(argv[1]) >> rows;
 	std::istringstream(argv[2]) >> columns;
-	std::istringstream(argv[3]) >> numColors;
+	if (argc == 6) {
+		std::istringstream(argv[3]) >> originRow;
+		std::istringstream(argv[4]) >> originColumn;
+	}
+	std::istringstream(argv[argc-1]) >> numColors;
 
 	// Initialize random number generator
 	std::random_device r;
@@ -21,8 +26,9 @@ int main(int argc, char **argv)
 	std::mt19937 mt(seed1);
 	std::uniform_int_distribution<int> uniform_dist(0, numColors - 1);
 
-	// Generate puzzle.
-	std::cout << rows << " " << columns << '\n';
+	// Generate puzzle. For now with origin (0, 0).
+	std::cout << rows << " " << columns << '\n'
+	          << originRow << " " << originColumn << '\n';
 	for (int i = 0; i < rows; ++i)
 	{
 		for (int j = 0; j < columns; ++j)


### PR DESCRIPTION
The origin of the flood fill is no longer hard-coded to `(0, 0)` and can instead be specified for each puzzle.